### PR TITLE
Remove default/cost from README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,8 +21,7 @@ The index.json describes your emoticon pack to us. It can contain the following 
  * *name* - The display name of the page.
  * *authors* - An array of strings indicating the original authors and their copyright status.
  * *emoticons* - A map of typed strings to their svg correspondents. For example, the entry `":)": "smile"` would cause `smile.svg` to be displayed in place of `:)`. Emoticon codes must not contain spaces, `<`, or `>` symbols.
- * *default* (optional) - Whether the emoticon pack should be "given" to all users by default.
- * *cost* (optional) - If you'd like your pack listed on the Beam store, you should include this section. It should be the number of Beam Points it costs to purchase the pack.
+
 
 ### License
 

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,6 @@ The index.json describes your emoticon pack to us. It can contain the following 
  * *authors* - An array of strings indicating the original authors and their copyright status.
  * *emoticons* - A map of typed strings to their svg correspondents. For example, the entry `":)": "smile"` would cause `smile.svg` to be displayed in place of `:)`. Emoticon codes must not contain spaces, `<`, or `>` symbols.
 
-
 ### License
 
 Every emotion in this pack is copyright by their respective owners, as indicated in their `index.json`. By submitting a pull request to this repository, you acknowledge that you own or have rights to distribute and sublicense the emoticons, and that your content does not infringe upon the intellectual property rights of a third party. By opening a pull request you understand that, while maintaining copyright, you grant Beam LLC a non-exclusive, transferable, sub-licensable, royalty-free, worldwide license to use the contents of your pull request on the Beam website (https://beam.pro) and that of related services.


### PR DESCRIPTION
The Beam store isn't around anymore, so it isn't really necessary for that to be in the README. At the very least, points should be replaced with sparks.