### PR TITLE
Include the size of each emote in its object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
+  - 4
 git:
   depth: 10

--- a/processing.js
+++ b/processing.js
@@ -169,7 +169,12 @@ exports.spritesheet = function (size, dir, target, callback) {
                 return cb();
             }
 
-            manifest.emoticons[code] = cached[name] = { x: x, y: y };
+            manifest.emoticons[code] = cached[name] = {
+                x, y,
+                width: size,
+                height: size
+            };
+
             ptr += 1;
 
             switch (stat.fmt) {


### PR DESCRIPTION
Hey it looks like Github finally decided to catch up 😄 

This adds a width and height to emote sizes during generation. This can be used to more easily allow us to adjust sizes in the future, particular with sub emotes; it would be a pain, lossy, and sort of a one-shot deal to write a migration to manually upscale all the sub emotes of all the partners. Better, I think, is recording the size of _all_ emotes (assuming 22x22 for backwards compatibility if undefined) and using these calculations when displaying it on the frontend. This would let us change sizes or even have specific higher-res (or lower-res) emotes in the future without any breaking changes or ugliness.

On the frontend this would just involve changing the emotes to use small canvas elements rather than image elements, which should perform and look better than the current somewhat hacky scaling solution.